### PR TITLE
Make scopes useable in templates

### DIFF
--- a/src/changelog.rs
+++ b/src/changelog.rs
@@ -62,10 +62,12 @@ impl<'a> Changelog<'a> {
             .unwrap_or(include_str!("../template.md"));
 
         let type_header = render::TypeHeader(self.config.type_headers.clone());
+        let scope_header = render::ScopeHeader(self.config.scope_headers.clone());
 
         tera.add_raw_template("template", template)?;
         tera.register_filter("indent", render::indent);
         tera.register_filter("typeheader", type_header);
+        tera.register_filter("scopeheader", scope_header);
 
         let mut log = tera.render("template", &context)?;
         if let Some(metadata) = &self.config.metadata {

--- a/src/changelog/change.rs
+++ b/src/changelog/change.rs
@@ -28,6 +28,11 @@ impl<'a> Change<'a> {
         &self.conventional.type_()
     }
 
+    /// The scope of the change.
+    pub(crate) fn scope(&self) -> Option<&str> {
+        self.conventional.scope()
+    }
+
     /// The short description of the change.
     pub(crate) fn description(&self) -> &str {
         self.conventional.description()
@@ -72,6 +77,7 @@ impl Serialize for Change<'_> {
 
         let mut state = serializer.serialize_struct("Change", 4)?;
         state.serialize_field("type", &self.type_())?;
+        state.serialize_field("scope", &self.scope())?;
         state.serialize_field("description", &self.description())?;
         state.serialize_field("body", &self.body())?;
         state.serialize_field("commit", &commit)?;

--- a/src/config.rs
+++ b/src/config.rs
@@ -11,6 +11,7 @@ pub struct Config {
     pub github: Option<Github>,
     pub accept_types: Option<Vec<String>>,
     pub type_headers: HashMap<String, String>,
+    pub scope_headers: HashMap<String, String>,
 
     #[serde(skip)]
     pub template: Option<String>,
@@ -39,6 +40,7 @@ impl Default for Config {
             github: None,
             accept_types: None,
             type_headers,
+            scope_headers: HashMap::new(),
             template: None,
             metadata: None,
         }

--- a/src/render.rs
+++ b/src/render.rs
@@ -11,6 +11,16 @@ impl Filter for TypeHeader {
     }
 }
 
+pub(crate) struct ScopeHeader(pub(crate) HashMap<String, String>);
+
+impl Filter for ScopeHeader {
+    fn filter(&self, value: &Value, _args: &HashMap<String, Value>) -> Result<Value> {
+        let ty = try_get_value!("scopeheader", "value", String, value);
+
+        to_value(self.0.get(&ty).unwrap_or(&ty)).map_err(Into::into)
+    }
+}
+
 pub(crate) fn indent(value: &Value, args: &HashMap<String, Value>) -> Result<Value> {
     let s = try_get_value!("indent", "value", String, value);
     let n = match args.get("n") {


### PR DESCRIPTION
This does what I described in \#17, and a bit more, which I figured out I needed after fiddling a bit with it locally.